### PR TITLE
Unify 's' rules with 1990 paper

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const stop = -1
 const intact = 0
 const cont = 1
 const protect = 2
+const contint = 3
 const vowels = /[aeiouy]/
 
 /**
@@ -116,8 +117,8 @@ const rules = {
     {match: 'ss', replacement: '', type: protect},
     {match: 'ous', replacement: '', type: cont},
     {match: 'us', replacement: '', type: intact},
-    {match: 's', replacement: '', type: cont},
-    {match: 's', replacement: '', type: stop}
+    {match: 's', replacement: '', type: contint},
+    {match: 's', replacement: 's', type: stop}
   ],
   t: [
     {match: 'plicat', replacement: 'ply', type: stop},
@@ -198,7 +199,7 @@ function applyRules(value, isIntact) {
   while (++index < ruleset.length) {
     const rule = ruleset[index]
 
-    if (!isIntact && rule.type === intact) {
+    if (!isIntact && (rule.type === intact || rule.type === contint)) {
       continue
     }
 
@@ -218,7 +219,7 @@ function applyRules(value, isIntact) {
       continue
     }
 
-    if (rule.type === cont) {
+    if (rule.type === cont || rule.type === contint) {
       return applyRules(next, false)
     }
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
-    *   [`lancasterStemmer(value)`](#lancasterstemmervalue)
+    *   [`lancasterStemmer(value, options?)`](#lancasterstemmervalue)
 *   [CLI](#cli)
 *   [Types](#types)
 *   [Compatibility](#compatibility)
@@ -78,7 +78,7 @@ lancasterStemmer('analytic') === lancasterStemmer('AnAlYtIc') // => true
 This package exports the identifier [`lancasterStemmer`][api-lancasterstemmer].
 There is no default export.
 
-### `lancasterStemmer(value)`
+### `lancasterStemmer(value, options?)`
 
 Get the stem from a given value.
 
@@ -86,6 +86,13 @@ Get the stem from a given value.
 
 *   `value`(`string`, required)
     — value to stem
+*   `options`(`object`, optional)
+    — options to use for stemmer
+
+The `options` object accepts one key, `ruleset`, with the values:
+* `1994` (default) - rules from the 1994 C implementation
+* `1990` - rules from the original paper and Pascal/Java implementations
+* `2014` - rules used in the initial version of this module
 
 ##### Returns
 

--- a/test.js
+++ b/test.js
@@ -184,9 +184,6 @@ test('api', function () {
 
   assert.ok(!m('abacs').endsWith('s'), 'should drop s$')
 
-  // `ation$` is also removed
-  assert.ok(m('compensation').endsWith('s'), 'should drop s$ only when intact')
-
   assert.ok(m('supplicat').endsWith('ply'), 'should transform plicat$ into ply')
 
   assert.ok(!m('surat').endsWith('at'), 'should drop at$')
@@ -263,6 +260,16 @@ test('api', function () {
   assert.ok(!m('showbiz').endsWith('iz'), 'should drop iz$')
 
   assert.ok(m('agryze').endsWith('ys'), 'should transform yz$ into ys')
+
+  assert.ok(
+    m('compensation', {ruleset: 'default'}).endsWith('n'),
+    'should drop s$'
+  )
+
+  assert.ok(
+    m('compensation', {ruleset: '1990'}).endsWith('s'),
+    'should protect s$ under 1990 rules'
+  )
 })
 
 test('cli', async function () {

--- a/test.js
+++ b/test.js
@@ -184,6 +184,9 @@ test('api', function () {
 
   assert.ok(!m('abacs').endsWith('s'), 'should drop s$')
 
+  // `ation$` is also removed
+  assert.ok(m('compensation').endsWith('s'), 'should drop s$ only when intact')
+
   assert.ok(m('supplicat').endsWith('ply'), 'should transform plicat$ into ply')
 
   assert.ok(!m('surat').endsWith('at'), 'should drop at$')


### PR DESCRIPTION
First off, thanks for this module! I'm converting some code to JavaScript, and was pleased to find this less-prevalent stemmer was already on npm.

When testing my own code's results, I discovered the results don't quite match the rules in the [original paper](https://doi.org/10.1145/101306.101310), which match implementations including [NLTK](https://www.nltk.org/_modules/nltk/stem/lancaster.html) and [my own](https://github.com/Hopper262/paice-husk-stemmer). There are two rules which are off:

* [line 119](https://github.com/words/lancaster-stemmer/blob/6ddc40659afef59c94875d396da743eebe2e4788/index.js#L119) uses type `cont`, but the paper's rules also set the `intact` flag. Without that, the subsequent rule is never accessed, so that doesn't seem right.
* [line 120](https://github.com/words/lancaster-stemmer/blob/6ddc40659afef59c94875d396da743eebe2e4788/index.js#L120) uses a blank replacement, but the paper uses 's' (zero characters removed).

I assume both of these are due to starting from the C/Perl implementations posted on the Lancaster site, rather than the Pascal/Java implementations. The one-off "contint" type instead of "continue" is easy to miss, and the stop rule is flat-out different. I suspect this latter change was a mistake introduced during the rule format conversion, rather than a deliberate evolution, but I don't have proof beyond a (long-lost and possibly misremembered) brief exchange with Dr. Paice years ago.

I'm not really a researcher and can't say whether these changes improve the stemming, but this PR improves compatibility with the other readily-available implementations FWIW. I've also added a new test case with an affected word ("compensation").